### PR TITLE
Adjust experience and projects layout

### DIFF
--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -273,7 +273,7 @@ export default function Experience() {
 
         {/* Experience Grid */}
         <div className="relative">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 grid-gap-xl max-w-7xl mx-auto">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 grid-gap-lg max-w-7xl mx-auto">
             {experiences.map((experience, index) => (
               <ExperienceCard 
                 key={experience.id} 

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -136,9 +136,7 @@ export default function Projects() {
       animate={{ opacity: 1, scale: 1 }}
       exit={{ opacity: 0, scale: 0.8 }}
       transition={{ duration: 0.5, delay: index * 0.1 }}
-      className={`group relative overflow-hidden rounded-2xl bg-gray-900/80 backdrop-blur-sm border border-gray-800 hover:border-[#4fc1c6]/50 transition-all duration-500 ${
-        project.featured ? 'md:col-span-2' : ''
-      }`}
+      className="group relative overflow-hidden rounded-2xl bg-gray-900/80 backdrop-blur-sm border border-gray-800 hover:border-[#4fc1c6]/50 transition-all duration-500"
       whileHover={{ y: -10, scale: 1.02 }}
     >
       {/* Background Gradient */}
@@ -341,7 +339,7 @@ export default function Projects() {
         {/* Projects Grid */}
         <motion.div
           layout
-          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 grid-gap-xl max-w-7xl mx-auto"
+          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 grid-gap-lg max-w-7xl mx-auto"
         >
           {filteredProjects.map((project, index) => (
             <ProjectCard key={project.id} project={project} index={index} />


### PR DESCRIPTION
Adjust grid spacing and ensure consistent 3-column layout for Experience and Projects components.

The Projects component previously allowed featured items to span 2 columns, which was inconsistent with the desired 3-column layout. This change ensures all projects adhere to the `lg:grid-cols-3` rule. Additionally, the `grid-gap` was reduced from `xl` to `lg` in both components for improved visual balance.

---

[Open in Web](https://cursor.com/agents?id=bc-72ee3e6d-fc48-4f4b-9df3-49801ebc104f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-72ee3e6d-fc48-4f4b-9df3-49801ebc104f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)